### PR TITLE
grommunio-setup: disable firewall rule to unsecure admin-web

### DIFF
--- a/grommunio-setup
+++ b/grommunio-setup
@@ -1233,7 +1233,6 @@ writelog "Config stage: open required firewall ports"
   firewall-cmd --add-port=143/tcp --zone=public --permanent
   firewall-cmd --add-port=587/tcp --zone=public --permanent
   firewall-cmd --add-port=993/tcp --zone=public --permanent
-  firewall-cmd --add-port=8080/tcp --zone=public --permanent
   firewall-cmd --add-port=8443/tcp --zone=public --permanent
   firewall-cmd --reload
 } >>"${LOGFILE}" 2>&1


### PR DESCRIPTION
As we always create a certificate we won't have to allow unsecure access to the
admin interface anymore by default.
